### PR TITLE
Graph percent of expenses covered on y axis

### DIFF
--- a/form.js
+++ b/form.js
@@ -309,9 +309,9 @@ form.initPlotly = function() {
       hoverformat: ".1f",
     },
     yaxis: {
-      title: "Percent Funded",
+      title: "Percent of expenses covered",
     },
-    title: "Time to Fully Fund Portfolio",
+    title: "Time to financial independence",
   };
   Plotly.newPlot("canvas_div", [], layout);
 };

--- a/form.js
+++ b/form.js
@@ -309,9 +309,9 @@ form.initPlotly = function() {
       hoverformat: ".1f",
     },
     yaxis: {
-      title: "Net worth",
+      title: "Percent Funded",
     },
-    title: "Time to financial independence",
+    title: "Time to Fully Fund Portfolio",
   };
   Plotly.newPlot("canvas_div", [], layout);
 };
@@ -335,12 +335,12 @@ form.graphCalculation = function(calculation, name, color) {
   var x = [];
   var y = [];
   var i = 0;
-  var nesteggs = [];
   var nestegg = calculation.nestegg();
   for (i = 0; i < networths.length; i++) {
     x.push((i/12));
-    y.push(networths[i]);
-    nesteggs.push(nestegg);
+    // How much of our portfolio has been funded so far?
+    var percent_funded = networths[i] / nestegg * 100;
+    y.push(percent_funded);
   }
 
   var data = {
@@ -355,24 +355,7 @@ form.graphCalculation = function(calculation, name, color) {
     legendgroup: name,
   };
 
-  // Also display a horizontal dashed line indicating the nest egg goal for
-  // this calculation
-  var nestegg = {
-    //x: x,
-    //y: nesteggs,
-    x: [0, networths.length / 12],
-    y: [calculation.nestegg(), calculation.nestegg()],
-    mode: "lines",
-    line: {
-      color: color,
-      dash: 10,
-    },
-    hoverinfo: "none",
-    legendgroup: name,
-    showlegend: false,
-  };
-
-  Plotly.addTraces("canvas_div", [data, nestegg]);
+  Plotly.addTraces("canvas_div", [data]);
 };
 
 


### PR DESCRIPTION
Previously, the y axis was the Networth and it wasn't super clear to some people why some scenarios stopped halfway up the graph (answer: those scenarios didn't need as much networth to be financially independent). Now it graphs the percent of expenses that are covered for by a scenario.

An example of what the graph used to look like:
![fi_graph_networth](https://cloud.githubusercontent.com/assets/2654835/24841854/af0b0ce6-1d42-11e7-9c96-1dad2ef796b3.png)

What the graph looks like with the changes made in this pull request:
![fi_graph_percent_covered](https://cloud.githubusercontent.com/assets/2654835/24841899/b80bba24-1d43-11e7-8204-61bee1bf9d1b.png)